### PR TITLE
Use PaletteColor in theme::palete_gen

### DIFF
--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,29 +1,30 @@
-use cursive::theme::Color::*;
+use cursive::theme;
 use cursive::theme::BaseColor::*;
 use cursive::theme::BorderStyle;
-use cursive::theme;
+use cursive::theme::Color::*;
+use cursive::theme::PaletteColor::*;
 
 pub fn palette_gen() -> theme::Palette {
-    let mut palette: theme::Palette = theme::Palette::default();
+    let mut palette = theme::Palette::default();
 
-    palette.set_color("background"         , Dark(Black));
-    palette.set_color("shadow"             , Light(Black));
-    palette.set_color("view"               , Dark(Black));
-    palette.set_color("primary"            , Dark(White));
-    palette.set_color("secondary"          , Light(Black));
-    palette.set_color("teritary"           , Dark(Green));
-    palette.set_color("title_primary"      , Dark(Blue));
-    palette.set_color("title_secondary"    , Dark(Green));
-    palette.set_color("highlight"          , Dark(Blue));
-    palette.set_color("highlight_inactive" , Light(Black));
+    palette[Background] = Dark(Black);
+    palette[Shadow] = Light(Black);
+    palette[View] = Dark(Black);
+    palette[Primary] = Dark(White);
+    palette[Secondary] = Light(Black);
+    palette[Tertiary] = Dark(Green);
+    palette[TitlePrimary] = Dark(Blue);
+    palette[TitleSecondary] = Dark(Green);
+    palette[Highlight] = Dark(Blue);
+    palette[HighlightInactive] = Light(Black);
 
     palette
 }
 
 pub fn theme_gen() -> theme::Theme {
-    let mut wikitheme = theme::load_default();
+    let mut wikitheme = theme::Theme::default();
 
-    wikitheme.shadow  = false;
+    wikitheme.shadow = false;
     wikitheme.borders = BorderStyle::Simple;
     wikitheme.palette = palette_gen();
 


### PR DESCRIPTION
This updates `palete_gen` to use `PaletteColor` instead of strings as indices, reducing the risk of typo (`tertiary` was mispelled `teritary`, though it wasn't used anywhere).