### PR TITLE
Refactor to allow the user to set the language and wiki

### DIFF
--- a/src/content.rs
+++ b/src/content.rs
@@ -10,10 +10,11 @@ use cursive::Cursive;
 use cursive::views::Dialog;
 use serde_json::Value;
 use self::regex::Regex;
+use CONFIGURATION;
 
 pub fn query_url_gen(title: &str) -> String {
     // query config
-    let mut url = String::from("https://en.wikipedia.org");
+    let mut url = CONFIGURATION.wiki_url.clone();
     url.push_str("/w/api.php?");
     url.push_str("action=query&");
     url.push_str("format=json&");
@@ -31,7 +32,7 @@ pub fn query_url_gen(title: &str) -> String {
 pub fn search_url_gen(search: &str) -> String {
     // search config
     let search = search.replace(" ", "%20");
-    let mut url = String::from("https://en.wikipedia.org");
+    let mut url = CONFIGURATION.wiki_url.clone();
     url.push_str("/w/api.php?");
     url.push_str("action=opensearch&");
     url.push_str("format=json&");


### PR DESCRIPTION
This commit allows the user to choose which wiki to browse using a command-line argument. In addition, it allows the user to choose the language when browsing Wikipedia (this flag is ignored when the user supplies a URL for a wiki). This pulls in two new crates, namely ``clap`` and ``lazy_static``, which are used to parse the arguments and store the values contained within, respectively. At the moment, the static struct used to store configuration values only stores the URL of the wiki to browse, but it could be used to store more configuration values in the future.